### PR TITLE
Appending XAJAX Functions Performance

### DIFF
--- a/vesuvius/mod/arrive/xajax.inc
+++ b/vesuvius/mod/arrive/xajax.inc
@@ -18,10 +18,10 @@ global $global;
 $global['xajax_functions'] = array();
 
 // publicly register accessible xajax funtions
-array_push($global['xajax_functions'], 'arrive_append_log');
-array_push($global['xajax_functions'], 'arrive_fetch_last_updated');
-array_push($global['xajax_functions'], 'arrive_show_list');
-array_push($global['xajax_functions'], 'arrive_add_spacer');
+$global['xajax_functions'][] = 'arrive_append_log';
+$global['xajax_functions'][] = 'arrive_fetch_last_updated';
+$global['xajax_functions'][] = 'arrive_show_list';
+$global['xajax_functions'][] = 'arrive_add_spacer';
 
 
 // adds a message to the log div @ tail

--- a/vesuvius/mod/em/xajax.inc
+++ b/vesuvius/mod/em/xajax.inc
@@ -17,16 +17,16 @@ global $global;
 $global['xajax_functions'] = array();
 
 // publicly register accessible xajax funtions
-array_push($global['xajax_functions'],'em_append_log');
-array_push($global['xajax_functions'],'em_prepend_log');
-array_push($global['xajax_functions'],'em_show_message');
-array_push($global['xajax_functions'],'em_show_events');
-array_push($global['xajax_functions'],'em_perform_edit');
-array_push($global['xajax_functions'],'em_perform_delete');
-array_push($global['xajax_functions'],'em_perform_purge');
-array_push($global['xajax_functions'],'em_perform_insert');
-array_push($global['xajax_functions'],'em_perform_save');
-array_push($global['xajax_functions'],'em_perform_help');
+$global['xajax_functions'][] = 'em_append_log';
+$global['xajax_functions'][] = 'em_prepend_log';
+$global['xajax_functions'][] = 'em_show_message';
+$global['xajax_functions'][] = 'em_show_events';
+$global['xajax_functions'][] = 'em_perform_edit';
+$global['xajax_functions'][] = 'em_perform_delete';
+$global['xajax_functions'][] = 'em_perform_purge';
+$global['xajax_functions'][] = 'em_perform_insert';
+$global['xajax_functions'][] = 'em_perform_save';
+$global['xajax_functions'][] = 'em_perform_help';
 
 // adds a message to the log div @ tail
 function em_append_log($message = "no message specified?") {

--- a/vesuvius/mod/eq/xajax.inc
+++ b/vesuvius/mod/eq/xajax.inc
@@ -17,15 +17,15 @@ global $global;
 $global['xajax_functions'] = array();
 
 // publicly register accessible xajax funtions
-array_push($global['xajax_functions'],'em_append_log');
-array_push($global['xajax_functions'],'em_prepend_log');
-array_push($global['xajax_functions'],'em_show_message');
-array_push($global['xajax_functions'],'em_show_events');
-array_push($global['xajax_functions'],'em_perform_edit');
-array_push($global['xajax_functions'],'em_perform_delete');
-array_push($global['xajax_functions'],'em_perform_insert');
-array_push($global['xajax_functions'],'em_perform_save');
-array_push($global['xajax_functions'],'em_perform_help');
+$global['xajax_functions'][] = 'em_append_log';
+$global['xajax_functions'][] = 'em_prepend_log';
+$global['xajax_functions'][] = 'em_show_message';
+$global['xajax_functions'][] = 'em_show_events';
+$global['xajax_functions'][] = 'em_perform_edit';
+$global['xajax_functions'][] = 'em_perform_delete';
+$global['xajax_functions'][] = 'em_perform_insert';
+$global['xajax_functions'][] = 'em_perform_save';
+$global['xajax_functions'][] = 'em_perform_help';
 
 // adds a message to the log div @ tail
 function em_append_log($message = "no message specified?") {

--- a/vesuvius/mod/ha/xajax.inc
+++ b/vesuvius/mod/ha/xajax.inc
@@ -19,15 +19,15 @@ global $global;
 $global['xajax_functions'] = array();
 
 // publicly register accessible xajax funtions
-array_push($global['xajax_functions'],'ha_append_log');
-array_push($global['xajax_functions'],'ha_prepend_log');
-array_push($global['xajax_functions'],'ha_show_message');
-array_push($global['xajax_functions'],'ha_show_hospitals');
-array_push($global['xajax_functions'],'ha_perform_edit');
-array_push($global['xajax_functions'],'ha_perform_delete');
-array_push($global['xajax_functions'],'ha_perform_insert');
-array_push($global['xajax_functions'],'ha_perform_save');
-array_push($global['xajax_functions'],'ha_perform_help');
+$global['xajax_functions'][] = 'ha_append_log';
+$global['xajax_functions'][] = 'ha_prepend_log';
+$global['xajax_functions'][] = 'ha_show_message';
+$global['xajax_functions'][] = 'ha_show_hospitals';
+$global['xajax_functions'][] = 'ha_perform_edit';
+$global['xajax_functions'][] = 'ha_perform_delete';
+$global['xajax_functions'][] = 'ha_perform_insert';
+$global['xajax_functions'][] = 'ha_perform_save';
+$global['xajax_functions'][] = 'ha_perform_help';
 
 // adds a message to the log div @ tail
 function ha_append_log($message = "no message specified?") {

--- a/vesuvius/mod/inw/xajax.inc
+++ b/vesuvius/mod/inw/xajax.inc
@@ -21,11 +21,11 @@ require_once($global['approot'].'/mod/inw/SearchDB.php');
 // publicly register accessible xajax funtions
 $global['xajax_functions'] = array();
 
-array_push($global['xajax_functions'],'inw_getData');
-array_push($global['xajax_functions'],'inw_checkForChanges');
-array_push($global['xajax_functions'],'inw_hasNextPage');
-array_push($global['xajax_functions'],'inw_getNotes');
-array_push($global['xajax_functions'],'inw_getAllCount');
+$global['xajax_functions'][] = 'inw_getData';
+$global['xajax_functions'][] = 'inw_checkForChanges';
+$global['xajax_functions'][] = 'inw_hasNextPage';
+$global['xajax_functions'][] = 'inw_getNotes';
+$global['xajax_functions'][] = 'inw_getAllCount';
 
 function inw_getNotes($uuid) {
 	global $global;

--- a/vesuvius/mod/rez/xajax.inc
+++ b/vesuvius/mod/rez/xajax.inc
@@ -18,20 +18,20 @@ require_once($global['approot'].'/mod/rez/handler_locale.inc');
 $global['xajax_functions'] = array();
 
 // publicly register accessible xajax funtions
-array_push($global['xajax_functions'],'rez_append_log');
-array_push($global['xajax_functions'],'rez_prepend_log');
-array_push($global['xajax_functions'],'rez_show_message');
-array_push($global['xajax_functions'],'rez_show_pages');
-array_push($global['xajax_functions'],'rez_show_help');
-array_push($global['xajax_functions'],'rez_perform_edit');
-array_push($global['xajax_functions'],'rez_perform_delete');
-array_push($global['xajax_functions'],'rez_perform_translate');
-array_push($global['xajax_functions'],'rez_perform_insert');
-array_push($global['xajax_functions'],'rez_perform_save');
-array_push($global['xajax_functions'],'rez_perform_move_up');
-array_push($global['xajax_functions'],'rez_perform_move_down');
-array_push($global['xajax_functions'],'rez_perform_change_visibility');
-array_push($global['xajax_functions'],'rez_perform_change_locale');
+$global['xajax_functions'][] = 'rez_append_log';
+$global['xajax_functions'][] = 'rez_prepend_log';
+$global['xajax_functions'][] = 'rez_show_message';
+$global['xajax_functions'][] = 'rez_show_pages';
+$global['xajax_functions'][] = 'rez_show_help';
+$global['xajax_functions'][] = 'rez_perform_edit';
+$global['xajax_functions'][] = 'rez_perform_delete';
+$global['xajax_functions'][] = 'rez_perform_translate';
+$global['xajax_functions'][] = 'rez_perform_insert';
+$global['xajax_functions'][] = 'rez_perform_save';
+$global['xajax_functions'][] = 'rez_perform_move_up';
+$global['xajax_functions'][] = 'rez_perform_move_down';
+$global['xajax_functions'][] = 'rez_perform_change_visibility';
+$global['xajax_functions'][] = 'rez_perform_change_locale';
 
 //Initialize locale array
 global $global;

--- a/vesuvius/mod/snap/xajax.inc
+++ b/vesuvius/mod/snap/xajax.inc
@@ -17,15 +17,15 @@ global $global;
 $global['xajax_functions'] = array();
 
 // publicly register accessible xajax funtions
-array_push($global['xajax_functions'],'snap_dim');
-array_push($global['xajax_functions'],'snap_append_log');
-array_push($global['xajax_functions'],'snap_prepend_log');
-array_push($global['xajax_functions'],'snap_show_message');
-array_push($global['xajax_functions'],'snap_show_backups');
-array_push($global['xajax_functions'],'snap_perform_backup');
-array_push($global['xajax_functions'],'snap_perform_restore');
-array_push($global['xajax_functions'],'snap_perform_delete');
-array_push($global['xajax_functions'],'snap_perform_rename');
+$global['xajax_functions'][] = 'snap_dim';
+$global['xajax_functions'][] = 'snap_append_log';
+$global['xajax_functions'][] = 'snap_prepend_log';
+$global['xajax_functions'][] = 'snap_show_message';
+$global['xajax_functions'][] = 'snap_show_backups';
+$global['xajax_functions'][] = 'snap_perform_backup';
+$global['xajax_functions'][] = 'snap_perform_restore';
+$global['xajax_functions'][] = 'snap_perform_delete';
+$global['xajax_functions'][] = 'snap_perform_rename';
 
 
 // dims the snapshotDiv while an action is being performed


### PR DESCRIPTION
Increase performance by not calling array_push() every time. array_push
is recommended for pushing multiple values in one function call. After
performing a few tests,, this is only good when you are pushing >= 30
values, otherwise $array[] = 'value'; is best, it takes 1/2 the time of
calling array_push().
