### PR TITLE
Resource Pages - Fails to prompt the user of unsaved changes when leaving the page

### DIFF
--- a/vesuvius/mod/rez/xajax.inc
+++ b/vesuvius/mod/rez/xajax.inc
@@ -536,7 +536,7 @@ function rez_perform_edit($page_id, $locale) {
 	<tr><td class=\"mainRowOdd\" style=\"text-align: center; text-weight: bold;\">"._t("ResourcePages-Table-Header|Locale")."</td><td class=\"mainRowOdd\"><input name=\"locale\" type=\"text\" id=\"locale\" value=\"".$row['rez_locale']."\" onchange=\"window.rezPageSaved = false;\" size=\"64\" /></td></tr>
 	<tr><td class=\"mainRowEven\" style=\"text-align: center; text-weight: bold;\">"._t("ResourcePages-Table-Header|Last Modified")."</td><td class=\"mainRowEven\"> &nbsp; ".$row['rez_timestamp']."</td></tr>
 	</table>
-	<div class=\"wysiwyg\"><textarea name=\"pageContent\" onkeypress=\"window.rezPageSaved = false;\" id=\"pageContent\" style=\"height: 300px; width: 100%;\">".$row['rez_content']."</textarea></div>
+	<div class=\"wysiwyg\"><textarea name=\"pageContent\" onchange=\"window.rezPageSaved = false;\" id=\"pageContent\" style=\"height: 300px; width: 100%;\">".$row['rez_content']."</textarea></div>
 	</form>";
 
 	$editControlHtml = '


### PR DESCRIPTION
issue: If you click 'Edit' on a page , make a change, and close the tab/ reload the tab, it does not warn to save before leave.
